### PR TITLE
Reduce regex backtracking

### DIFF
--- a/src/Filter/AttributeCleaner.php
+++ b/src/Filter/AttributeCleaner.php
@@ -4,6 +4,7 @@ namespace Phlib\XssSanitizer\Filter;
 
 use Phlib\XssSanitizer\AttributeFinder;
 use Phlib\XssSanitizer\FilterInterface;
+use Phlib\XssSanitizer\TagFinderInterface;
 use Phlib\XssSanitizer\TagFinder;
 
 /**
@@ -13,7 +14,7 @@ use Phlib\XssSanitizer\TagFinder;
 class AttributeCleaner implements FilterInterface
 {
     /**
-     * @var TagFinder
+     * @var TagFinderInterface
      */
     protected $tagFinder;
 
@@ -41,7 +42,7 @@ class AttributeCleaner implements FilterInterface
      */
     public function __construct($attribute, FilterInterface $attributeContentCleaner, $tags = null)
     {
-        $this->tagFinder  = $tags ? new TagFinder($tags) : new TagFinder($attribute, TagFinder::BY_ATTR);
+        $this->tagFinder  = $tags ? new TagFinder\ByTag($tags) : new TagFinder\ByAttribute($attribute);
         $this->attrFinder = new AttributeFinder($attribute);
 
         $this->contentRegex = $this->buildContentRegex();

--- a/src/Filter/MetaRefresh.php
+++ b/src/Filter/MetaRefresh.php
@@ -13,7 +13,7 @@ use Phlib\XssSanitizer\TagFinder;
 class MetaRefresh implements FilterInterface
 {
     /**
-     * @var TagFinder
+     * @var TagFinder\ByTag
      */
     protected $tagFinder;
 
@@ -33,7 +33,7 @@ class MetaRefresh implements FilterInterface
      */
     public function __construct(FilterInterface $attributeContentCleaner)
     {
-        $this->tagFinder  = new TagFinder('meta');
+        $this->tagFinder  = new TagFinder\ByTag('meta');
         $this->attrFinder = new AttributeFinder('http-equiv');
 
         $this->attributeContentCleaner = $attributeContentCleaner;

--- a/src/Filter/RemoveAttributes.php
+++ b/src/Filter/RemoveAttributes.php
@@ -14,7 +14,7 @@ class RemoveAttributes implements FilterInterface
 {
 
     /**
-     * @var TagFinder
+     * @var TagFinder\ByAttribute
      */
     protected $tagFinder;
 
@@ -49,7 +49,7 @@ class RemoveAttributes implements FilterInterface
             'seeksegmenttime',
         ];
 
-        $this->tagFinder       = new TagFinder($attributes, TagFinder::BY_ATTR);
+        $this->tagFinder       = new TagFinder\ByAttribute($attributes);
         $this->attributeFinder = new AttributeFinder($attributes);
     }
 

--- a/src/TagFinder/ByAttribute.php
+++ b/src/TagFinder/ByAttribute.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Phlib\XssSanitizer\TagFinder;
+
+use Phlib\XssSanitizer\TagFinderInterface;
+
+/**
+ * Class ByAttribute
+ * @package Phlib\XssSanitizer\TagFinder\ByTag
+ */
+class ByAttribute implements TagFinderInterface
+{
+
+    /**
+     * @var string
+     */
+    protected $initialSearchRegex;
+
+    /**
+     * ByAttribute constructor
+     * @param string|string[] $attributes
+     */
+    public function __construct($attributes)
+    {
+        $this->initialSearchRegex = $this->initInitialSearchRegex($attributes);
+    }
+
+    /**
+     * Given a full html string, finds the required tags by attribute and calls the callback,
+     * providing the full tag string and the attributes string
+     *
+     * @param string $str
+     * @param callable $callback
+     * @return string
+     */
+    public function findTags($str, callable $callback)
+    {
+        $searchOffset = 0;
+        while (preg_match($this->initialSearchRegex, $str, $matches, PREG_OFFSET_CAPTURE, $searchOffset)) {
+            $attr   = $matches[0][0];
+            $offset = $matches[0][1];
+
+            $searchOffset = $offset + strlen($attr);
+
+            $startOfTag = $this->findStartOfTag(substr($str, 0, $offset));
+            if (!$startOfTag) {
+                continue;
+            }
+            $endOfTag = $this->findEndOfTag(substr($str, $offset + strlen($attr)));
+            if (!$endOfTag) {
+                continue;
+            }
+
+            $fullTag    = implode('', [$startOfTag[0], $attr, $endOfTag[0]]);
+            $attributes = implode('', [$startOfTag[1], $attr, $endOfTag[1]]);
+
+            $replacement = $callback($fullTag, $attributes);
+
+            $tagOffset = $offset - strlen($startOfTag[0]);
+            $str = substr_replace($str, $replacement, $tagOffset, strlen($fullTag));
+
+            // continue searching from after the end of the replaced tag
+            $searchOffset = $tagOffset + strlen($replacement);
+        }
+
+        return $str;
+    }
+
+    /**
+     * Build the search regex based on the attributes specified
+     *
+     * @param string|string[] $attributes
+     * @return string
+     */
+    protected function initInitialSearchRegex($attributes)
+    {
+        if (is_array($attributes)) {
+            $attributes = '(?:' . implode('|', $attributes) . ')';
+        }
+
+        return implode('', [
+            '#',
+                '(?<!\w)',
+                $attributes,
+                '[^0-9a-z"\'=>]*', // https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet#Non-alpha-non-digit_XSS
+                '=',
+            '#si',
+        ]);
+    }
+
+    /**
+     * Finds the start of the tag from the attribute found
+     *
+     * If the start of the tag is found, returns the matches array with the full tag start and attributes start
+     * If not found, returns null
+     *
+     * @param string $beforeStr
+     * @return array|null
+     */
+    protected function findStartOfTag($beforeStr)
+    {
+        // Searching backwards from the found attribute
+        $startTag = preg_match('#^([^>]+)[a-z+]<#si', strrev($beforeStr), $matches);
+        if (!$startTag) {
+            return null;
+        } else {
+            // reverse back again
+            return array_map('strrev', $matches);
+        }
+    }
+
+    /**
+     * Finds the end of the tag from the attribute found
+     *
+     * If the end of the tag is found, returns the matches array with the full tag end and attributes end
+     * If not found, returns null
+     *
+     * @param string $afterStr
+     * @return array|null
+     */
+    protected function findEndOfTag($afterStr)
+    {
+        $endTag = preg_match('#^([^>]+)>#si', $afterStr, $matches);
+        if (!$endTag) {
+            return null;
+        } else {
+            return $matches;
+        }
+    }
+
+}

--- a/src/TagFinder/ByAttribute.php
+++ b/src/TagFinder/ByAttribute.php
@@ -100,7 +100,7 @@ class ByAttribute implements TagFinderInterface
     protected function findStartOfTag($beforeStr)
     {
         // Searching backwards from the found attribute
-        $startTag = preg_match('#^([^>]+)[a-z+]<#si', strrev($beforeStr), $matches);
+        $startTag = preg_match('#^([^>]+)[a-z]<#si', strrev($beforeStr), $matches);
         if (!$startTag) {
             return null;
         } else {

--- a/src/TagFinder/ByAttribute.php
+++ b/src/TagFinder/ByAttribute.php
@@ -6,7 +6,7 @@ use Phlib\XssSanitizer\TagFinderInterface;
 
 /**
  * Class ByAttribute
- * @package Phlib\XssSanitizer\TagFinder\ByTag
+ * @package Phlib\XssSanitizer\TagFinder
  */
 class ByAttribute implements TagFinderInterface
 {

--- a/src/TagFinder/ByTag.php
+++ b/src/TagFinder/ByTag.php
@@ -67,7 +67,7 @@ class ByTag implements TagFinderInterface
         return implode('', [
             '#<',
             $tags,
-            '[^a-z0-9>]+([^>]*?)(?:>|$)',
+            '[^a-z0-9>]+([^>]*)(?:>|$)',
             '#i'
         ]);
     }

--- a/src/TagFinder/ByTag.php
+++ b/src/TagFinder/ByTag.php
@@ -1,37 +1,31 @@
 <?php
 
-namespace Phlib\XssSanitizer;
+namespace Phlib\XssSanitizer\TagFinder;
+
+use Phlib\XssSanitizer\TagFinderInterface;
 
 /**
- * Class TagFinder
+ * Class ByTag
  * @package Phlib\XssSanitizer
  */
-class TagFinder
+class ByTag implements TagFinderInterface
 {
-    const BY_TAG  = 1;
-    const BY_ATTR = 2;
-
     /**
      * @var string
      */
     protected $searchRegex;
 
     /**
-     * TagFinder constructor
-     * @param string|string[] $searchValues
-     * @param int $mode                         Should be either TagFinder::BY_TAG or TagFinder::BY_ATTR
+     * ByTag constructor
+     * @param string|string[] $tags
      */
-    public function __construct($searchValues, $mode = self::BY_TAG)
+    public function __construct($tags)
     {
-        if ($mode == self::BY_ATTR) {
-            $this->searchRegex = $this->initByAttrRegex($searchValues);
-        } else {
-            $this->searchRegex = $this->initByTagRegex($searchValues);
-        }
+        $this->searchRegex = $this->initSearchRegex($tags);
     }
 
     /**
-     * Given a full html string, finds the required tags by either tag name or attribute and calls the callback,
+     * Given a full html string, finds the required tags by either tag name and calls the callback,
      * providing the full tag string and the attributes string
      *
      * The return value is used to replace the full tag string
@@ -65,7 +59,7 @@ class TagFinder
      * @param string|string[] $tags
      * @return string
      */
-    protected function initByTagRegex($tags)
+    protected function initSearchRegex($tags)
     {
         if (is_array($tags)) {
             $tags = '(?:' . implode('|', $tags) . ')';
@@ -75,28 +69,6 @@ class TagFinder
             $tags,
             '[^a-z0-9>]+([^>]*?)(?:>|$)',
             '#i'
-        ]);
-    }
-
-    /**
-     * Build the search regex based on the attributes specified
-     *
-     * @param string|string[] $attributes
-     * @return string
-     */
-    protected function initByAttrRegex($attributes)
-    {
-        if (is_array($attributes)) {
-            $attributes = '(?:' . implode('|', $attributes) . ')';
-        }
-        return implode('',[
-            '#',
-                '<[a-z]+([^>]+',
-                '(?<!\w)',
-                    $attributes,
-                '[^0-9a-z"\'=]*', // https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet#Non-alpha-non-digit_XSS
-                '=[^>]+)>',
-            '#si',
         ]);
     }
 }

--- a/src/TagFinderInterface.php
+++ b/src/TagFinderInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Phlib\XssSanitizer;
+
+/**
+ * Interface TagFinderInterface
+ * @package Phlib\XssSanitizer
+ */
+interface TagFinderInterface
+{
+
+    /**
+     * Given a full html string, finds the required tags by either tag name or attribute and calls the callback,
+     * providing the full tag string and the attributes string
+     *
+     * The return value is used to replace the full tag string
+     *
+     * e.g. for an tag finder which is looking for an img tag
+     * for the string
+     *     '<body><img src="something"></body'
+     * the callback will provide
+     *     $fullTag:    '<img src="something">'
+     *     $attributes: ' src="something"'
+     * and the return from the callback would replace the $fullTag in the original string
+     *
+     * @param string $str
+     * @param callable $callback
+     * @return string
+     */
+    public function findTags($str, callable $callback);
+
+}

--- a/tests/TagFinder/ByAttributeTest.php
+++ b/tests/TagFinder/ByAttributeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace TagFinder;
+
+use Phlib\XssSanitizer\TagFinder;
+
+class ByAttributeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFindTagsCallbackArgs()
+    {
+        $tagFinder = new TagFinder\ByAttribute('title');
+
+        $str = '<html><body><a title="something"></body></html>';
+        $expectedFullTag    = '<a title="something">';
+        $expectedAttributes = ' title="something"';
+        $callback = function($fullTag, $attributes) use ($expectedFullTag, $expectedAttributes) {
+            $this->assertEquals($expectedFullTag, $fullTag);
+            $this->assertEquals($expectedAttributes, $attributes);
+        };
+        $tagFinder->findTags($str, $callback);
+    }
+
+    public function testFindTagsMultipleAttributes()
+    {
+        $tagFinder = new TagFinder\ByAttribute(['title', 'name']);
+
+        $str = '<html><body><a title="something"><br /><a name="thename"></body></html>';
+        $expectedFullTags = [
+            '<a title="something">',
+            '<a name="thename">',
+        ];
+        $actualFullTags = [];
+        $callback = function($fullTag) use (&$actualFullTags) {
+            $actualFullTags[] = $fullTag;
+        };
+        $tagFinder->findTags($str, $callback);
+
+        $this->assertEquals(2, count($actualFullTags));
+        $this->assertEquals($expectedFullTags, $actualFullTags);
+    }
+
+    /**
+     * @dataProvider findTagsReplacementDataProvider
+     * @param string $str
+     * @param string $replacement
+     * @param string $expected
+     */
+    public function testFindTagsReplacement($str, $replacement, $expected)
+    {
+        $tagFinder = new TagFinder\ByAttribute('title');
+
+        $replacer = function() use ($replacement) {
+            return $replacement;
+        };
+        $expected = vsprintf($expected, [$replacement]);
+        $actual   = $tagFinder->findTags($str, $replacer);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function findTagsReplacementDataProvider()
+    {
+        $r = '<!--replacement!-->';
+        return [
+            ['<html><body><a title="something"></body></html>', $r, "<html><body>$r</body></html>"],
+            ['<html><body><a title="something"><a title="something"></body></html>', $r, "<html><body>$r$r</body></html>"],
+        ];
+    }
+
+}

--- a/tests/TagFinder/ByAttributeTest.php
+++ b/tests/TagFinder/ByAttributeTest.php
@@ -52,7 +52,6 @@ class ByAttributeTest extends \PHPUnit_Framework_TestCase
         $replacer = function() use ($replacement) {
             return $replacement;
         };
-        $expected = vsprintf($expected, [$replacement]);
         $actual   = $tagFinder->findTags($str, $replacer);
 
         $this->assertEquals($expected, $actual);


### PR DESCRIPTION
The important stuff is in`\Phlib\XssSanitizer\TagFinder\ByAttribute::findTags`.

I've changed it so that rather than looking for the whole tag (starting with the `<`, then working along to find the attribute), it now looks directly for the attribute we're looking for, then works backwards to find the start of the tag, and forwards to find the end.

The code gets a little bit messy from there in order to keep using the 'callback' in the same way with the same arguments, and making sure that we're still doing the replacement the same as was previously being done by the `preg_replace_callback`.
