### PR TITLE
Added Static Call and Make Method With Clean Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,27 @@ This library was created to try to solve the problem of XSS sanitization without
 
 This library is also intended for a limited use case whereby it is assumed that the sanitized HTML is only going to be displayed in a limited set of supported browsers (e.g. no need to strip 'vbscript:' code).
 
+## Installation
+
+Using Composer just run:
+
+```
+composer require phlib/xss-sanitizer
+```
+
 ## Usage
 
 Create a sanitizer and sanitize some input
 
 ``` php
 $sanitizer = new \Phlib\XssSanitizer\Sanitizer();
-$sanitized = $sanitizer->sanitize($htmlInput);
+$sanitized = $sanitizer->sanitize($html);
+```
 
+Or use the static method signature to change that into a one-liner:
+
+```php
+$sanitized = \Phlib\XssSanitizer\Sanitizer::clean($html);
 ```
 
 ## Supported Browsers

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -26,6 +26,39 @@ class Sanitizer
     }
 
     /**
+     * Forward static calls as non-static calls.
+     *
+     * @param  string $method to be called
+     * @param  array $arguments to be passed to called method
+     * @return mixed
+     */
+    public static function __callStatic($method, $arguments)
+    {
+        return call_user_func_array([self::make(), $method], $arguments);
+    }
+
+    /**
+     * Make a new instance of Sanitizer
+     *
+     * @return \Phlib\XssSanitizer\Sanitizer
+     */
+    public static function make()
+    {
+        return new static;
+    }
+
+    /**
+     * Sanitize a HTML string
+     *
+     * @param string $str
+     * @return string
+     */
+    protected function clean($str)
+    {
+        return $this->sanitize($str);
+    }
+
+    /**
      * Sanitize a HTML string
      *
      * @param string $str

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -20,6 +20,12 @@ class SanitizerTest extends \PHPUnit_Framework_TestCase
     {
         $actual = (new Sanitizer())->sanitize($original);
         $this->assertEquals($expected, $actual);
+
+        $actual = Sanitizer::make()->sanitize($original);
+        $this->assertEquals($expected, $actual);
+
+        $actual = Sanitizer::clean($original);
+        $this->assertEquals($expected, $actual);
     }
 
     public function sanitizeDataProvider()


### PR DESCRIPTION
This allows for `Sanitizer::clean($str)` syntax which makes it more of a one liner. Alternatively you could do `Sanitizer::make()->sanitize($str)` which is the equivalent. Also updated instructions in readme.
