### PR TITLE
Fix attribute cleaner error when filtered tag has empty content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Attribute cleaner error when filtered tag has empty content.
 
 ## [2.0.0] - 2021-08-17
 ### Added

--- a/src/AttributeFinder.php
+++ b/src/AttributeFinder.php
@@ -105,9 +105,10 @@ class AttributeFinder
         $filtered[] = preg_replace_callback(
             $this->pessimisticSearchRegex,
             function ($matches) use ($callback) {
+                $attributeContents = '';
                 if (isset($matches[2]) && $matches[2]) {
                     $attributeContents = $matches[2]; // quoted contents
-                } else {
+                } elseif (isset($matches[3]) && $matches[3]) {
                     $attributeContents = $matches[3]; // unquoted contents
                 }
                 return $callback($matches[0], $attributeContents);

--- a/tests/Filter/AttributeCleanerTest.php
+++ b/tests/Filter/AttributeCleanerTest.php
@@ -106,9 +106,55 @@ class AttributeCleanerTest extends TestCase
     public function cleanBackgroundAnyTagDataProvider(): array
     {
         return [
-            ['<div background="javascript:alert(\'XSS\')">', '<div >'],
-            ['<body background="javascript:alert(\'XSS\')">', '<body >'],
-            ['<span background="javascript:alert(\'XSS\')">', '<span >'],
+            'remove-attr-div-dblquote' => [
+                '<div background="javascript:alert(\'XSS\')">',
+                '<div >',
+            ],
+            'remove-attr-div-snglquote' => [
+                '<div background=\'javascript:alert("XSS")\'>',
+                '<div >',
+            ],
+            'remove-attr-div-noquote' => [
+                '<div background=javascript:alert(\'XSS\')>',
+                '<div >',
+            ],
+            'remove-attr-body-dblquote' => [
+                '<body background="javascript:alert(\'XSS\')">',
+                '<body >',
+            ],
+            'remove-attr-body-snglquote' => [
+                '<body background=\'javascript:alert("XSS")\'>',
+                '<body >',
+            ],
+            'remove-attr-body-noquote' => [
+                '<body background=javascript:alert(\'XSS\')>',
+                '<body >',
+            ],
+            'remove-attr-span-dblquote' => [
+                '<span background="javascript:alert(\'XSS\')">',
+                '<span >',
+            ],
+            'remove-attr-span-snglquote' => [
+                '<span background=\'javascript:alert("XSS")\'>',
+                '<span >',
+            ],
+            'remove-attr-span-noquote' => [
+                '<span background=javascript:alert(\'XSS\')>',
+                '<span >',
+            ],
+
+            'valid-pessimistic-empty-dblquote' => [
+                '<div style="color:red;" background="">',
+                '<div style="color:red;" background="">',
+            ],
+            'valid-pessimistic-empty-snglquote' => [
+                '<div style="color:red;" background=\'\'>',
+                '<div style="color:red;" background=\'\'>',
+            ],
+            'valid-pessimistic-empty-noquote' => [
+                '<div style="color:red;" background= >',
+                '<div style="color:red;" background= >',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Neither match is non-empty if the attribute has no value.
Add more tests for different quote styles.