### PR TITLE
Exclude tests files when installing the lib

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.github/ export-ignore
+/test-ui/ export-ignore
+/tests/ export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/ecs.php export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
Hi @chrisminett 

When installing this lib with composer the tests folder and some config files are not needed
<img width="191" alt="image" src="https://github.com/phlib/xss-sanitizer/assets/9052536/cff7146a-0a90-4a83-bb4b-a3f34590ca91">

That's the purpose of the export ignore directive